### PR TITLE
add link to open all pages found

### DIFF
--- a/client/grep.coffee
+++ b/client/grep.coffee
@@ -97,15 +97,28 @@ emit = ($item, item) ->
   [program, listing, errors] = parse item.text
   $item.append """
     <div style="background-color:#eee;padding:15px;">
-      <div class=listing>#{listing}</div>
+      <div class=listing>#{listing} <a class=open href='#'>»</a></div>
       <p class="caption">#{errors} errors</p>
       <p class="result"></p>
     </div>
   """
   run $item, program unless errors
 
+
+open_all = (this_page, titles) ->
+  for title in titles
+    wiki.doInternalLink title, this_page
+    this_page = null
+
 bind = ($item, item) ->
   $item.dblclick -> wiki.textEditor $item, item
+  $item.find('a.open').click (e) ->
+    e.stopPropagation()
+    e.preventDefault()
+    this_page = $item.parents('.page') unless e.shiftKey
+    open_all this_page, $item.find('a.internal').map -> $(this).text()
+
+
 
 window.plugins.grep = {emit, bind} if window?
 module.exports = {parse, evalPart, evalPage} if module?

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wiki-plugin-grep",
-  "version": "0.1.5",
+  "version": "1.0.0",
   "description": "Federated Wiki - Grep Plugin",
   "keywords": [
     "grep",

--- a/pages/about-grep-plugin
+++ b/pages/about-grep-plugin
@@ -13,6 +13,11 @@
     },
     {
       "type": "paragraph",
+      "id": "a465975def8c370d",
+      "text": "Grep lists the pages that it finds. Click » to open them."
+    },
+    {
+      "type": "paragraph",
       "id": "1ee19086ebde9810",
       "text": "[[Grep for All Videos]] that use the new video plugin."
     },
@@ -252,6 +257,27 @@
         "text": "This plugin retrieves all pages from the origin server and creates links to those that satisfy conditions specified by a specialized markup. See [[About Grep Markup]]"
       },
       "date": 1420431687095
+    },
+    {
+      "type": "add",
+      "id": "a465975def8c370d",
+      "item": {
+        "type": "paragraph",
+        "id": "a465975def8c370d",
+        "text": "Grep lists the pages that it finds. Click » to open all found pages in the lineup."
+      },
+      "after": "b4c8615f53245ece",
+      "date": 1497140833655
+    },
+    {
+      "type": "edit",
+      "id": "a465975def8c370d",
+      "item": {
+        "type": "paragraph",
+        "id": "a465975def8c370d",
+        "text": "Grep lists the pages that it finds. Click » to open them."
+      },
+      "date": 1497140863599
     }
   ]
 }


### PR DESCRIPTION
This pull request adds a link » to open the pages found.

I've updated this to version 1.0.0 because it has been stable for some time now.

![image](https://user-images.githubusercontent.com/12127/27007309-c02ad80c-4e03-11e7-805f-4aede27dd914.png)
