### PR TITLE
add button to start search

### DIFF
--- a/client/grep.coffee
+++ b/client/grep.coffee
@@ -97,13 +97,14 @@ emit = ($item, item) ->
   [program, listing, errors] = parse item.text
   $item.append """
     <div style="background-color:#eee;padding:15px;">
-      <div class=listing>#{listing} <a class=open href='#'>»</a></div>
-      <p class="caption">#{errors} errors</p>
+      <div style="text-align:center">
+        <div class=listing>#{listing} <a class=open href='#'>»</a></div>
+        <button>find</button>
+        <p class="caption">#{errors} errors</p>
+      </div>
       <p class="result"></p>
     </div>
   """
-  run $item, program unless errors
-
 
 open_all = (this_page, titles) ->
   for title in titles
@@ -112,6 +113,9 @@ open_all = (this_page, titles) ->
 
 bind = ($item, item) ->
   $item.dblclick -> wiki.textEditor $item, item
+  $item.find('button').click (e) ->
+    [program, listing, errors] = parse item.text
+    run $item, program unless errors
   $item.find('a.open').click (e) ->
     e.stopPropagation()
     e.preventDefault()

--- a/client/grep.coffee
+++ b/client/grep.coffee
@@ -95,12 +95,13 @@ run = ($item, program) ->
 
 emit = ($item, item) ->
   [program, listing, errors] = parse item.text
+  caption = if errors then "#{errors} errors" else 'ready'
   $item.append """
     <div style="background-color:#eee;padding:15px;">
       <div style="text-align:center">
         <div class=listing>#{listing} <a class=open href='#'>»</a></div>
         <button>find</button>
-        <p class="caption">#{errors} errors</p>
+        <p class="caption">#{caption}</p>
       </div>
       <p class="result"></p>
     </div>


### PR DESCRIPTION
I have always resisted using this plugin because it creates a lot of network traffic by just looking at it. We could consider better ways to implement it. But even with server-side help, I still think we would want a button to kick off the search.

Here Grep is ready to run.

![image](https://user-images.githubusercontent.com/12127/35197655-31faa4c8-fe97-11e7-88da-2ab4cbc22aca.png)

Press `find` to start the search.

![image](https://user-images.githubusercontent.com/12127/35197667-657de1c0-fe97-11e7-98e3-73840c45f3cd.png)
